### PR TITLE
Write MAC egress command at correct offset

### DIFF
--- a/apps/lab5/wire_main.c
+++ b/apps/lab5/wire_main.c
@@ -190,7 +190,7 @@ send_packet( struct nbi_meta_catamaran *nbi_meta,
     uint16_t q_dst = 0;
 
     /* Write the MAC egress CMD and adjust offset and len accordingly */
-    pkt_off = PKT_NBI_OFFSET + MAC_PREPEND_BYTES;
+    pkt_off = PKT_NBI_OFFSET + 2 * MAC_PREPEND_BYTES;
     island = nbi_meta->pkt_info.isl;
     pnum   = nbi_meta->pkt_info.pnum;
     pbuf   = pkt_ctm_ptr40(island, pnum, 0);
@@ -202,7 +202,7 @@ send_packet( struct nbi_meta_catamaran *nbi_meta,
 
     pkt_mac_egress_cmd_write(pbuf, pkt_off, 1, 1); // Write data to make the packet MAC egress generate L3 and L4 checksums
 
-    msi = pkt_msd_write(pbuf, pkt_off); // Write a packet modification script of NULL
+    msi = pkt_msd_write(pbuf, pkt_off - MAC_PREPEND_BYTES); // Write a packet modification script of NULL
     pkt_nbi_send(island,
                  pnum,
                  &msi,


### PR DESCRIPTION
NOTE:
- MAC_PREPEND_BYTES is defined as 4 bytes
  Packet contains 8 bytes of metadata (4B timestamp + 4B MAC ingress)
  Payload starts at PKT_NBI_OFFSET + 8 bytes
- pkt_mac_egress_cmd_write() adds the cmd at offset - 4.
  offset must point to payload start (refer to flowenv/lib/pkt.h)
- pkt_msd_write() accepts offset to payload (or the MAC egress command
  that may precede it). Length and Offset must include the MAC egress
  command that is prepended to payload.
- Causes random packet corruption in TCP packets without this change!

Signed-off-by: Rajath Shashidhara <rajaths@cs.utexas.edu>